### PR TITLE
Protect categories on delete

### DIFF
--- a/ToDoListV99/Controllers/CategoriesController.cs
+++ b/ToDoListV99/Controllers/CategoriesController.cs
@@ -101,7 +101,7 @@ namespace ToDoListV99.Controllers
             if (category == null)
             {
                 return HttpNotFound();
-            }
+            }        
             return View(category);
         }
 
@@ -110,9 +110,23 @@ namespace ToDoListV99.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult DeleteConfirmed(int id)
         {
+            //see if this category is tied to any lists
+            //if tied to lists delete category and join
             Category category = db.Categories.Find(id);
+            var Results = from ltc in db.ListsToCategories
+                          where ltc.CategoryId == id
+                          select ltc.ListToCategoryId;
+            // get rid of all the join instances
+            foreach (var item in Results)
+            {
+                ListToCategory ltc = db.ListsToCategories.Find(item);
+                db.ListsToCategories.Remove(ltc);
+            }
+            
             db.Categories.Remove(category);
             db.SaveChanges();
+            
+           
             return RedirectToAction("Index");
         }
 

--- a/ToDoListV99/Controllers/ListsController.cs
+++ b/ToDoListV99/Controllers/ListsController.cs
@@ -276,7 +276,7 @@ namespace ToDoListV99.Controllers
 
         /************* add categories to a list **********************/
 
-        // GET: Lists/Edit/5
+        // GET:
         public ActionResult AddCategoriesToAList(int? id)
         {
             CurrentListID = id.ToString();
@@ -289,11 +289,6 @@ namespace ToDoListV99.Controllers
             {
                 return HttpNotFound();
             }
-
-
-
-
-            //return View(list);
 
             var Results = from c in db.Categories
                            select new
@@ -324,7 +319,6 @@ namespace ToDoListV99.Controllers
 
         }
 
-        // POST: Lists/Edit/5
         // To protect from overposting attacks, please enable the specific properties you want to bind to, for 
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
@@ -352,7 +346,6 @@ namespace ToDoListV99.Controllers
                         db.ListsToCategories.Add(new ListToCategory() { ListId = list.ListId, CategoryId = item.Id });
                     }
                 }
-                //db.Entry(list).State = EntityState.Modified;
                 db.SaveChanges();
                 return RedirectToAction("Index");
             }

--- a/ToDoListV99/Models/ListsViewModel.cs
+++ b/ToDoListV99/Models/ListsViewModel.cs
@@ -9,7 +9,6 @@ namespace ToDoListV99.Models
     {
         public int ListId { get; set; }
         public string ListName { get; set; }
-        public List<CheckBoxViewModel> Categories { get; set; }//is the name CAtegories a problem?
-
+        public List<CheckBoxViewModel> Categories { get; set; }
     }
 }

--- a/ToDoListV99/ToDoListV99.csproj
+++ b/ToDoListV99/ToDoListV99.csproj
@@ -220,9 +220,7 @@
     <Content Include="Views\Lists\Details.cshtml" />
     <Content Include="Views\Lists\Edit.cshtml" />
     <Content Include="Views\Lists\Index.cshtml" />
-
     <Content Include="Views\Lists\ViewItems.cshtml" />
-
     <Content Include="Views\Lists\_ItemTable.cshtml" />
     <Content Include="Views\Lists\_ListTable.cshtml" />
     <Content Include="Views\Categories\Create.cshtml" />
@@ -230,9 +228,7 @@
     <Content Include="Views\Categories\Details.cshtml" />
     <Content Include="Views\Categories\Edit.cshtml" />
     <Content Include="Views\Categories\Index.cshtml" />
-
     <Content Include="Views\Lists\AddCategoriesToAList.cshtml" />
-
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />


### PR DESCRIPTION
altered the category delete action so that it would also delete the instances in the join table to avoid getting nulls in the category checkboxes